### PR TITLE
docs: Update for Neutron dICS mainnet deployments

### DIFF
--- a/Neutron_dICS_Programs.md
+++ b/Neutron_dICS_Programs.md
@@ -176,3 +176,97 @@ Testnet pion-1 deployment checklist
 | | `secure_return_unspent_tokens` | Neutron DAO + Security DAO | Must include "process_function" and "forward" parameters | |
 | | `secure_update_lp_forward_config` | Neutron DAO + Security DAO | Must include "update_config" and "new_config" parameters | |
 | | `secure_update_usdc_forwarder_config` | Neutron DAO + Security DAO | Must include "update_config" and "new_config" parameters | |
+
+## Mainnet Parameters
+
+Each program requires specific parameters for deployment. The following tables list the required parameters for each program.
+
+### Program 1: NTRN Allocation
+| Parameter | Description | Value |
+|-----------|-------------|--------|
+| `owner` | Program owner address | `neutron1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrstdxvff` |
+| `ntrn_denom` | NTRN token denomination | "untrn" |
+| `vp2_instant_ls_receiver_address` | Address to receive NTRN for instant liquid stake | TODO Program 2's receiver address |
+| `vp2_instant_ls_amount` | Amount of NTRN for instant liquid stake | "77500000000000" (77.5M NTRN) |
+| `vp3_gradual_ls_receiver_address` | Address to receive NTRN for gradual liquid stake | TODO Program 3's receiver address |
+| `vp3_gradual_ls_amount` | Amount of NTRN for gradual liquid stake | "100000000000000" (100M NTRN) |
+| `vp4_bootstrap_liquidity_receiver_address` | Address to receive NTRN for bootstrap liquidity | TODO Program 4's receiver address |
+| `vp4_bootstrap_liquidity_amount` | Amount of NTRN for bootstrap liquidity | "25000000000000" (25M NTRN) |
+| `neutron_dao_addr` | Neutron DAO address | `neutron1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrstdxvff` |
+| `operator_list` | List of addresses authorized for low-security operations | `["neutron1qxatg2nkmsf26cymcg2saeh9l2cqp0s2xms7xd", "neutron1ze09kc5ackut7wc4pf38lysu45kfz3msr98nru", "neutron1h8vf3ueml7ah7m8z9e6vx09trq5lv2fw9e049f", "neutron1tf0uhd8hs7tqxw2pdrlvzenkugkyfa2jh82ndu", "neutron14mlpd48k5vkeset4x7f78myz3m47jcax3ysjkp", "neutron1v45lnmf3h3ujdh4pyegpt24y60nsh758q2yna7"]` |
+
+### Program 2: Instant Liquid Stake
+| Parameter | Description | Value |
+|-----------|-------------|--------|
+| `owner` | Program owner address | `neutron1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrstdxvff` |
+| `ntrn_denom` | NTRN token denomination | "untrn" |
+| `dntrn_denom` | dNTRN token denomination | TODO |
+| `neutron_dao_addr` | Neutron DAO address | `neutron1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrstdxvff` |
+| `vp4_bootstrap_liquidity_receiver_addr` | Address to receive dNTRN for bootstrap liquidity | TODO Program 4's receiver address |
+| `drop_liquid_staker_addr` | Drop protocol contract address | TODO Mainnet Drop protocol address |
+| `ntrn_dao_split_normalized_fraction` | Fraction of dNTRN to send to Neutron DAO | "0.6775" |
+| `vp4_receiver_split_normalized_fraction` | Fraction of dNTRN to send to Program 4 | "0.3225" |
+| `operator_list` | List of addresses authorized for low-security operations | `["neutron1qxatg2nkmsf26cymcg2saeh9l2cqp0s2xms7xd", "neutron1ze09kc5ackut7wc4pf38lysu45kfz3msr98nru", "neutron1h8vf3ueml7ah7m8z9e6vx09trq5lv2fw9e049f", "neutron1tf0uhd8hs7tqxw2pdrlvzenkugkyfa2jh82ndu", "neutron14mlpd48k5vkeset4x7f78myz3m47jcax3ysjkp", "neutron1v45lnmf3h3ujdh4pyegpt24y60nsh758q2yna7"]` |
+
+### Program 3: Gradual Liquid Stake
+| Parameter | Description | Value |
+|-----------|-------------|--------|
+| `owner` | Program owner address | `neutron1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrstdxvff` |
+| `ntrn_denom` | NTRN token denomination | "untrn" |
+| `drop_liquid_staker_addr` | Drop protocol contract address | TODO Mainnet Drop protocol address |
+| `max_amount_to_forward` | Maximum amount to forward in each batch | "6500000000000" (6.5M NTRN) |
+| `interval_seconds_between_batches` | Time between batches. Use 1 week | "604800" |
+| `neutron_dao_addr` | Neutron DAO address | `neutron1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrstdxvff` |
+| `security_dao_addr` | Security DAO address | `neutron1xc95vsacskqcqtyzmwfr5h7qaz60h0z3ksnz65l2ah4s85tyqrns7dyqmy` |
+| `operator_list` | List of addresses authorized for low-security operations | `["neutron1qxatg2nkmsf26cymcg2saeh9l2cqp0s2xms7xd", "neutron1ze09kc5ackut7wc4pf38lysu45kfz3msr98nru", "neutron1h8vf3ueml7ah7m8z9e6vx09trq5lv2fw9e049f", "neutron1tf0uhd8hs7tqxw2pdrlvzenkugkyfa2jh82ndu", "neutron14mlpd48k5vkeset4x7f78myz3m47jcax3ysjkp", "neutron1v45lnmf3h3ujdh4pyegpt24y60nsh758q2yna7"]` |
+
+### Program 4: Bootstrap NTRN-dNTRN
+| Parameter | Description | Value |
+|-----------|-------------|--------|
+| `owner` | Program owner address | `neutron1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrstdxvff` |
+| `ntrn_denom` | NTRN token denomination | "untrn" |
+| `dntrn_denom` | dNTRN token denomination | TODO |
+| `astroport_pool_addr` | Astroport pool address | TODO Mainnet NTRN-dNTRN pool address |
+| `expected_pool_ratio_min` | Minimum pool ratio for liquidity provision | "0.98" |
+| `expected_pool_ratio_max` | Maximum pool ratio for liquidity provision | "1.02" |
+| `pool_max_spread` | Maximum acceptable spread when swapping | "0.02" |
+| `ntrn_forwarder_amount` | Maximum NTRN amount to forward | "100000000000000" |
+| `dntrn_forwarder_amount` | Maximum dNTRN amount to forward | "100000000000000" |
+| `forwarder_interval_between_calls` | Time between forward operations | "1" |
+| `neutron_dao_addr` | Neutron DAO address | `neutron1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrstdxvff` |
+| `security_dao_addr` | Security DAO address | `neutron1xc95vsacskqcqtyzmwfr5h7qaz60h0z3ksnz65l2ah4s85tyqrns7dyqmy` |
+| `operator_list` | List of addresses authorized for low-security operations | `["neutron1qxatg2nkmsf26cymcg2saeh9l2cqp0s2xms7xd", "neutron1ze09kc5ackut7wc4pf38lysu45kfz3msr98nru", "neutron1h8vf3ueml7ah7m8z9e6vx09trq5lv2fw9e049f", "neutron1tf0uhd8hs7tqxw2pdrlvzenkugkyfa2jh82ndu", "neutron14mlpd48k5vkeset4x7f78myz3m47jcax3ysjkp", "neutron1v45lnmf3h3ujdh4pyegpt24y60nsh758q2yna7"]` |
+
+### Program 5: Migrate USDC-NTRN
+| Parameter | Description | Value |
+|-----------|-------------|--------|
+| `owner` | Program owner address | `neutron1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrstdxvff` |
+| `ntrn_denom` | NTRN token denomination | "untrn" |
+| `dntrn_denom` | dNTRN token denomination | TODO |
+| `usdc_denom` | USDC token denomination | `ibc/B559A80D62249C8AA07A380E2A2BEA6E5CA9A6F079C912C3A9E9B494105E4F81` |
+| `usdc_ntrn_lp_denom` | USDC-NTRN LP token denomination | `factory/neutron18c8qejysp4hgcfuxdpj4wf29mevzwllz5yh8uayjxamwtrs0n9fshq9vtv/astroport/share` |
+| `usdc_ntrn_lp_max_batch_size` | Maximum LP tokens to process in each batch | "100000000000" |
+| `usdc_ntrn_lp_batch_interval_seconds` | Time between processing batches | "1" |
+| `usdc_ntrn_pool_addr` | USDC-NTRN pool address | `neutron18c8qejysp4hgcfuxdpj4wf29mevzwllz5yh8uayjxamwtrs0n9fshq9vtv` |
+| `drop_liquid_staker_addr` | Drop protocol contract address | TODO Mainnet Drop protocol address |
+| `usdc_dntrn_pool_addr` | USDC-dNTRN pool address | TODO Mainnet USDC-dNTRN pool address |
+| `expected_pool_ratio_min` | Minimum pool ratio for liquidity provision | TODO -10% |
+| `expected_pool_ratio_max` | Maximum pool ratio for liquidity provision | TODO +10% |
+| `pool_max_spread` | Maximum acceptable spread when swapping | "0.10" |
+| `neutron_dao_addr` | Neutron DAO address | `neutron1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrstdxvff` |
+| `security_dao_addr` | Security DAO address | `neutron1xc95vsacskqcqtyzmwfr5h7qaz60h0z3ksnz65l2ah4s85tyqrns7dyqmy` |
+| `operator_list` | List of addresses authorized for low-security operations | `["neutron1qxatg2nkmsf26cymcg2saeh9l2cqp0s2xms7xd", "neutron1ze09kc5ackut7wc4pf38lysu45kfz3msr98nru", "neutron1h8vf3ueml7ah7m8z9e6vx09trq5lv2fw9e049f", "neutron1tf0uhd8hs7tqxw2pdrlvzenkugkyfa2jh82ndu", "neutron14mlpd48k5vkeset4x7f78myz3m47jcax3ysjkp", "neutron1v45lnmf3h3ujdh4pyegpt24y60nsh758q2yna7"]` |
+| `usdc_forwarder_max_amount` | Maximum USDC amount to forward | "100000000000000" |
+| `return_forwarder_max_amount` | Maximum amount to return | "100000000000000" |
+
+## Useful commands
+
+### Querying pools
+
+To query pool information:
+
+```bash
+neutrond q wasm contract-state smart <POOL_ADDRESS> '{"pool":{}}' --chain-id neutron-1 --node https://neutron-rpc.polkachu.com:443 --output json | jq
+```
+
+This will return an array of assets. The pool ratio is defined by amount of the first asset divided by the amount of the second asset.

--- a/Neutron_dICS_Programs.md
+++ b/Neutron_dICS_Programs.md
@@ -83,12 +83,13 @@ Due to dependencies in the programs, programs should be deployed in reverse orde
 
 ## Testing and Rehearsals
 
-## Mainnet Fork Deployment
-Before using in production, please do the following:
-1. Make a copy of `mainnet.toml` files in each program's `program_param` folder and give it a suitable name. A good name is `<test_date>_<chain_name>_<label>.toml`.
-2. Ensure every subroutine from every program has been executed in the tests. Use the Subroutine Authorization Matrix to confirm test results.
+For detailed information about each program's configuration parameters, subroutines, and security model, please refer to the individual program READMEs linked above.
 
-Mainnet fork deployment checklist
+Programs have been deployed in the following environments:
+<details>
+<summary>Mainnet Fork Deployment</summary>
+
+#### Mainnet fork deployment
 1. Deployed. Program ID 12
   - Receiver address is `neutron1u3fsk7ycfmp8dpxdtxyrc8lgpqjk0w5xc82vqn9hdxnrru8jt3ssj7majv`
 2. Deployed. Program ID 11
@@ -101,10 +102,12 @@ Mainnet fork deployment checklist
 5. Deployed. Program ID 7
   - Receiver address for USDC-NTRN-LP shares `neutron12eawpnrularsa84fr5yz6jj4w9tq2jj23fck7ye7m0vxkl9elu4qy7rshm`
 
-## Testnet (pion-1) Deployment
-Before using in production, please do the following:
-1. Make a copy of `fork.toml` files in each program's `program_param` folder and give it a suitable name. A good name is `testnet.toml`.
-2. Ensure every subroutine from every program has been executed in the tests. Use the Subroutine Authorization Matrix to confirm test results.
+</details>
+
+<details>
+<summary> Testnet (pion-1) Deployment</summary>
+
+#### Pion-1 deployment
 
 Values different from mainnet fork deployment:
 - DAO address: `neutron1kvxlf27r0h7mzjqgdydqdf76dtlyvwz6u9q8tysfae53ajv8urtq4fdkvy`
@@ -139,8 +142,9 @@ Testnet pion-1 deployment checklist
   - Receiver address for dNTRN and NTRN `neutron1wwyrj5nh8z4jvc36yugpy9f7sdx3d694faknkln673sf4xcs4apsvmwmz0`
 5. Deployed. Program ID 1
   - Receiver address for USDC-NTRN-LP shares `neutron1qaaf9lv99pwyeaf7ktw37wetyzpper28j6cltqgw600g3gtsac4s64wtx2`
+</details>
 
-### Subroutine Authorization Matrix
+## Subroutine Authorization Matrix
 
 | Program | Subroutine | Authorization | Parameter Restrictions | Test Status |
 |---------|------------|---------------|------------------------|-------------|

--- a/Neutron_dICS_Programs.md
+++ b/Neutron_dICS_Programs.md
@@ -245,8 +245,8 @@ Each program requires specific parameters for deployment. The following tables l
 | `dntrn_denom` | dNTRN token denomination | TODO |
 | `usdc_denom` | USDC token denomination | `ibc/B559A80D62249C8AA07A380E2A2BEA6E5CA9A6F079C912C3A9E9B494105E4F81` |
 | `usdc_ntrn_lp_denom` | USDC-NTRN LP token denomination | `factory/neutron18c8qejysp4hgcfuxdpj4wf29mevzwllz5yh8uayjxamwtrs0n9fshq9vtv/astroport/share` |
-| `usdc_ntrn_lp_max_batch_size` | Maximum LP tokens to process in each batch | "100000000000" |
-| `usdc_ntrn_lp_batch_interval_seconds` | Time between processing batches | "1" |
+| `usdc_ntrn_lp_max_batch_size` | Maximum LP tokens to process in each batch | TODO Should be ~10 batches|
+| `usdc_ntrn_lp_batch_interval_seconds` | Time between processing batches | TODO Should be 1 day |
 | `usdc_ntrn_pool_addr` | USDC-NTRN pool address | `neutron18c8qejysp4hgcfuxdpj4wf29mevzwllz5yh8uayjxamwtrs0n9fshq9vtv` |
 | `drop_liquid_staker_addr` | Drop protocol contract address | TODO Mainnet Drop protocol address |
 | `usdc_dntrn_pool_addr` | USDC-dNTRN pool address | TODO Mainnet USDC-dNTRN pool address |

--- a/Neutron_dICS_Programs.md
+++ b/Neutron_dICS_Programs.md
@@ -4,7 +4,7 @@ There are five programs Timewave is deploying to support Neutron's monetary poli
 These include the following.
 
 1. **NTRN Allocation Program**: This program receives 202.5M NTRN and allocates them to the other programs. See [program details](programs/2025-03-23-prod-dICS-ntrn-allocation/README.md).
-2. **Instant liquid-stake NTRN Program**: This program receives 77.5M NTRN which is liquid staked using the Drop protocol immediately. A fraction of 0.6775, ~100M dNTRN is returned to the DAO. A fraction of 0.3225, ~25M dNTRN is sent to bootstrap NTRN and dNTRN liquidity, i.e., program 4. See [program details](programs/2025-03-23-prod-dICS-ntrn-instant-ls/README.md).
+2. **Instant liquid-stake NTRN Program**: This program receives 77.5M NTRN which is liquid staked using the Drop protocol immediately. A fraction of 0.6775, ~52.5M dNTRN is returned to the DAO. A fraction of 0.3225, ~25M dNTRN is sent to bootstrap NTRN and dNTRN liquidity, i.e., program 4. See [program details](programs/2025-03-23-prod-dICS-ntrn-instant-ls/README.md).
 3. **Gradual liquid-stake NTRN program**: This program receives 100M NTRN and it liquid stakes these gradually over three months. See [program details](programs/2025-03-23-prod-dICS-gradual-ls/README.md).
 4. **Bootstrap NTRN and dNTRN liquidity program**: This program receives NTRN from program 1 and dNTRN from program 2. It provides liquidity to the Astroport pool and returns the LP share tokens to the Neutron DAO. See [program details](programs/2025-03-23-prod-bootstrap-ntrn-dntrn-liquidity/README.md).
 5. **Migrate USDC-NTRN liquidity program**: This program receives the USDC-NTRN liquidity LP tokens from the Neutron DAO. It withdraws the liquidity, liquid stakes the NTRN, and enters the USDC-dNTRN liquidity pool. Liquidity tokens are sent back to the Neutron DAO. See [program details](programs/2025-03-23-prod-migrate-usdc-ntrn-liquidity/README.md).
@@ -150,17 +150,17 @@ Testnet pion-1 deployment checklist
 |---------|------------|---------------|------------------------|-------------|
 | **Program 1: NTRN Allocation** |
 | | `split_ntrn` | Operators | Must include "process_function" and "liquid_stake" parameters | |
-| | `update_split_config` | Neutron DAO + Security DAO | Must include "update_config" and "new_config" parameters | |
+| | `update_split_config` | Neutron DAO only | Must include "update_config" and "new_config" parameters | |
 | **Program 2: Instant Liquid Stake** |
 | | `liquid_stake` | Operators | Must include "process_function" and "liquid_stake" parameters | |
 | | `split_to_provide` | Operators | Must include "process_function" and "split" parameters | |
-| | `secure_update_split_config` | Neutron DAO + Security DAO | Must include "update_config" and "new_config" parameters | |
+| | `secure_update_split_config` | Neutron DAO only | Must include "update_config" and "new_config" parameters | |
 | **Program 3: Gradual Liquid Stake** |
 | | `liquid_stake_batch` | Operators | Must include "process_function" and "liquid_stake" parameters | |
 | | `forward_batch` | Operators | Must include "process_function" and "forward" parameters | |
 | | `secure_update_forwarder_config` | Neutron DAO + Security DAO | Must include "update_config" and "new_config" parameters | |
 | **Program 4: Bootstrap NTRN-dNTRN** |
-| | `secure_send_tokens_to_dao` | Security DAO | Controlled by forwarder config parameters | |
+| | `secure_send_tokens_to_dao` | Neutron DAO + Security DAO | Controlled by forwarder config parameters | |
 | | `double_sided_lp` | Operators | Pool ratio must be between constrained `expected_pool_ratio_min` and `expected_pool_ratio_max` | |
 | | `secure_double_sided_lp` | Security DAO | Can set the `expected_pool_ratio_min` and `expected_pool_ratio_max` while providing liquidity | |
 | | `secure_single_sided_lp` | Security DAO | Can set the `expected_pool_ratio_min` and `expected_pool_ratio_max` and `max_spread` | |

--- a/README.md
+++ b/README.md
@@ -1,55 +1,78 @@
-# Program deployer
+# Timewave Program Deployments
 
-This is a CLI tool to deploy programs using the manager on different environments
+This repository contains scripts and program definitions for [Valence Programs](https://docs.valence.zone) that the Timewave team has deployed.
 
-It will allow you to use rust to build your program config for deployment, but also allow you to provide a program config in json format.
+## Overview
 
-# How to
+This repository includes:
+- Templates for creating new programs
+- Environment-specific configuration management
+- Build and deployment scripts
+- Documentation for existing deployments
 
-## .env
+## Index of Deployments
+- [Neutron dICS Deployments](./Neutron_dICS_Programs.md)
 
-You must include `.env` file in the root of the project with the following variables:
+## Getting Started
+Please follow this guide to create and deploy your own program. 
+
+### Prerequisites
+- Rust toolchain
+- Familiarity with [Valence](https://docs.valence.zone)
+- A wallet funded with tokens for gas
+
+### Set up `.env`
+
+You must include `.env` file in the root directory with the mnemonic of a funded wallet that will be used to deploy programs.
 
 ```env
-# The mnemonic that will be used by the manager to deploy the program on chains
+# The mnemonic that will be used by the program manager to deploy the program on chains
 MANAGER_MNEMONIC=""
 ```
 
-## Clone the template
+### Clone the template
 
-A template is provided to help you get started, you can clone it and modify it to deploy your program.
+A [template](./programs/program_template/) is provided to help you get started. You can copy the directory in its entirety and modify it to build and deploy your program.
 
-Don't forget to rename the new program directory and the `Cargo.toml` file.
+Don't forget to rename the new program directory and the program name in the `Cargo.toml` file.
 
-## Program builder
+### Program builder
 
-In your new program directory you will find `src/program_builder.rs` file, this is the file that you will modify to build your program using our rust builder pattern.
+In your new program directory you will find `src/program_builder.rs` file, this is the file that you will modify to create your program. You will be using the Rust builder pattern to write the program.
 
-## Program parameters
+### Environment specific program parameters
 
-Your program might need some parameters that are unique for a specific environment, you can provide these parameters in the `program_params/` directory.
+Your program may need parameters that are unique for a specific deployment environment. For example, you may want to use particular parameters for a testnet deployment and different parameters for mainnet, while building the program from the *same* `src/program_builder.rs` file.
 
-You should include a file for each environment, the file name should be the environment name, Example: `program_params/local.toml` or `program_params/mainnet.toml`.
+You can provide these parameters in the `program_params/` directory.
+
+You should include a file for each environment. The file name should be the environment name. For example, you might have `program_params/local.toml` or `program_params/mainnet.toml`.
+
+For every environment you must make sure that there is an equivalent directory in `manager_configs`.
 
 Any parameter that is included there will be available in the program builder function, and can be retrieved using the `.get(String)` function, Example: `params.get("my_param")`.
 
-## Run the script
+### Build and deploy
 
-You can run your program using the following command:
+You can build and deploy your program using the following command:
 
 ```bash
-cargo run -p *PROGRAM_NAME*
+cargo run -p <PROGRAM_NAME> -- --target-env <ENVIRONMENT>
 ```
 
-Use the name you gave your pgoram in `Cargo.toml` file.
+Use the program name you gave your program in `Cargo.toml` file.
 
-## Output
+### Output
 
 After running the script, you will find the output in the `output/` directory.
 
-Each deployed program will have its own directory with the date and time of the deployment, inside each directory you will find:
+Each deployed program will have its own directory with the date and time of the deployment. Inside each directory you will find:
 
-- `instantiated-program-config.json` - The instantiated program config which includes all the addresses of the contracts of the deployed program
-- `raw-program-config.json` - The generated raw program config before instantiation.
+- `instantiated-program-config.json`: Which includes all the addresses of the contracts of the deployed program.
+- `raw-program-config.json`: Which includes the raw program config that resulted from the builder before instantiation.
 
 By default each deployed program directory is ignored in git, you can remove the ignore rule in the `.gitignore` file if you want to keep the output in your cloned repository.
+
+## Contributing
+
+Please ensure your changes follow the existing patterns and include appropriate documentation updates.

--- a/programs/2025-03-23-prod-dICS-ntrn-allocation/README.md
+++ b/programs/2025-03-23-prod-dICS-ntrn-allocation/README.md
@@ -40,7 +40,6 @@ The program accepts the following configuration parameters:
 - `vp4_bootstrap_liquidity_receiver_address`: Address to receive NTRN for bootstrap liquidity
 - `vp4_bootstrap_liquidity_amount`: Amount of NTRN for bootstrap liquidity
 - `neutron_dao_addr`: Address of the Neutron DAO
-- `security_dao_addr`: Address of the Security DAO
 - `operator_list`: List of addresses authorized for low-security operations
 
 ## Subroutines
@@ -66,7 +65,7 @@ The program implements a two-tier security model:
    - Includes routine operations like splitting NTRN
 
 2. High Security Operations
-   - Requires authorization from either Neutron DAO or Security DAO
+   - Requires authorization from the Neutron DAO
    - Includes critical operations like updating split configuration
 
 ## Directory structure

--- a/programs/2025-03-23-prod-dICS-ntrn-instant-ls/README.md
+++ b/programs/2025-03-23-prod-dICS-ntrn-instant-ls/README.md
@@ -3,12 +3,14 @@
 Please see Neutron [dICS Programs](../../Neutron_dICS_Programs.md) for background. This program is dICS Program 2.
 
 This directory provides support for building and deploying a program that performs instant liquid staking of NTRN tokens as part of Neutron's dICS initiative:
-- The program receives 125M NTRN from Program 1
+- The program receives NTRN from Program 1. Note that the Neutron DAO is expected to deposit 77.5M NTRN 
 - The program uses the Drop protocol to instantly liquid stake the NTRN
 - The program uses a splitter to distribute the resulting dNTRN per the following configuration:
-    - 100M dNTRN is returned to the Neutron DAO
-    - 25M dNTRN is sent to Program 4 for bootstrap liquidity
-- The split is performed using a ratio (0.8:0.2) rather than with fixed amounts
+    - ~52.5M dNTRN is returned to the Neutron DAO
+    - ~25M dNTRN is sent to Program 4 for bootstrap liquidity
+- The split is performed using a ratio (0.6775:0.3225) rather than with fixed amounts
+
+> Note: The testnet configuration in `testnet.toml` uses different split ratios (0.6666:0.3334) for testing purposes.
 
 ## Program structure
 ```mermaid
@@ -35,13 +37,12 @@ The program accepts the following configuration parameters:
 - `owner`: The owner address of the program
 - `ntrn_denom`: The denomination of NTRN tokens (e.g., "untrn")
 - `dntrn_denom`: The denomination of dNTRN tokens
-- `neutron_dao_addr`: Address to receive 100M dNTRN
-- `vp4_bootstrap_liquidity_receiver_addr`: Address to receive 25M dNTRN
+- `neutron_dao_addr`: Address of the Neutron DAO. Expected to receive ~52.5M NTRN
+- `vp4_bootstrap_liquidity_receiver_addr`: Address to receive ~25M dNTRN
 - `drop_liquid_staker_addr`: Address of the Drop protocol contract
-- `security_dao_addr`: Address of the Security DAO
 - `operator_list`: Array of addresses authorized for low-security operations
-- `ntrn_dao_split_normalized_fraction`: String representation of the percentage of liquid staked assets to be sent to Neutron DAO (e.g., "0.8" = 80%)
-- `vp4_receiver_split_normalized_fraction`: String representation of the percentage of liquid staked assets to be sent to Program 4 (e.g., "0.2" = 20%)
+- `ntrn_dao_split_normalized_fraction`: String representation of the percentage of liquid staked assets to be sent to Neutron DAO (e.g., "0.6775" = 67.75%)
+- `vp4_receiver_split_normalized_fraction`: String representation of the percentage of liquid staked assets to be sent to Program 4 (e.g., "0.3225" = 32.25%)
 
 ## Subroutines
 
@@ -61,7 +62,7 @@ The program includes the following subroutines:
 
 3. `secure_update_split_config`
    - Purpose: Updates the splitter configuration
-   - Authorization: Neutron DAO and Security DAO only
+   - Authorization: Neutron DAO only
    - Function: Updates critical program parameters
    - Message Restrictions: Must include "update_config" and "new_config" parameters
 
@@ -75,7 +76,7 @@ The program implements a two-tier security model:
    - No call limits on authorized functions
 
 2. High Security Operations
-   - Requires authorization from either Neutron DAO or Security DAO
+   - Requires authorization from the Neutron DAO
    - Includes critical operations like updating program configuration
    - No call limits on authorized functions
 
@@ -89,6 +90,7 @@ This is a single program builder with the following structure:
     - `program_builder.rs` - Program builder code that defines the program configuration
 - `program_params/` - Program parameters for different environments
     - `mainnet.toml` - Production configuration
+    - `testnet.toml` - Testnet configuration
 
 ## Version History
 


### PR DESCRIPTION
Only contains doc updates. I'd like multiple eyes on the mainnet params section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Revised token allocation with adjusted dNTRN splits (~52.5M returned to the DAO and ~25M for liquidity) and updated deposit expectations.
	- Simplified key operation approvals now requiring authorization exclusively from the Neutron DAO.

- **Documentation**
	- Restructured deployment guides and setup instructions for improved clarity and organization.
	- Updated parameter descriptions and removed outdated configuration details for enhanced usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->